### PR TITLE
[FIXED JENKINS-33155] Not consider pinned plugins to be upgraded

### DIFF
--- a/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
+++ b/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
@@ -296,7 +296,7 @@ public class PluginHelper extends Descriptor<PluginHelper> implements Describabl
         boolean cannotDynamicLoad = false;
         for (PluginWrapper wrapper : wrapperToFile.keySet()) {
             final PluginWrapper existing = pm.getPlugin(wrapper.getShortName());
-            if (existing != null && (existing.isActive() || existing.isEnabled())) {
+            if (existing != null && (existing.isActive() || existing.isEnabled()) && !existing.isPinned()) {
                 LOGGER.log(Level.INFO, "Cannot dynamically load optional plugins because {0} is already installed",
                         existing.getShortName());
                 cannotDynamicLoad = true;
@@ -373,6 +373,13 @@ public class PluginHelper extends Descriptor<PluginHelper> implements Describabl
                             new Object[]{shortName, existing.getVersion(), proposed.getVersion()});
                     continue;
                 }
+                if (existing.isPinned()) {
+                    LOGGER.log(Level.INFO,
+                            "Ignoring installing plugin {0} as it is pinned. You might want to unpin this plugin.",
+                            new Object[]{shortName});
+                    continue;
+                }
+
                 LOGGER.log(Level.INFO, "Restart required as plugin {0} is already installed", shortName);
                 cannotDynamicLoad = true;
             }


### PR DESCRIPTION
The issue was happens when the plugins are pinned, because it is blocking them from being upgraded. Once they unpinned, it worked fine.

We can ignore the .pinned fine and force an upgrade, or we can change PluginHelper.refresh to ignore pinned plugins when enumerating the optional plugins.

For the moment and until the behaviour of the .pinned files doesn't change when upgrading on jenkins-core, I think the best option is to change PluginHelper.refresh to ignore pinned plugins when enumerating the optional plugins as they don't need to be upgraded.

@reviewbybees @stephenc 
