### PR TITLE
[FIXED JENKINS-36351] Only cannotDynamicLoad when the plugin does not exist

### DIFF
--- a/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
+++ b/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
@@ -300,7 +300,7 @@ public class PluginHelper extends Descriptor<PluginHelper> implements Describabl
                 LOGGER.log(Level.INFO, "Cannot dynamically load optional plugins because {0} is already installed",
                         existing.getShortName());
                 cannotDynamicLoad = true;
-            } else if (YesNoMaybe.NO == wrapper.supportsDynamicLoad()) {
+            } else if (existing == null && YesNoMaybe.NO == wrapper.supportsDynamicLoad()) {
                 LOGGER.log(Level.INFO,
                         "Cannot dynamically load optional plugins because {0} does not support dynamic load",
                         wrapper.getShortName());


### PR DESCRIPTION
If I understand correctly the code disabled plugins are considered installable:
https://github.com/jenkinsci/optional-plugin-helper-module/blob/2994c72c377d05eab48793e94dbbdcdf238ae79f/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java#L297-L308
Specifically, the line of code below should also check that the plugin does not exist
https://github.com/jenkinsci/optional-plugin-helper-module/blob/2994c72c377d05eab48793e94dbbdcdf238ae79f/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java#L303

@reviewbybees CC @stephenc 
