### PR TITLE
[JENKINS-36820] Correctly expose the version

### DIFF
--- a/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
+++ b/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java
@@ -335,7 +335,7 @@ public class PluginHelper extends Descriptor<PluginHelper> implements Describabl
                 if (v == null || v.isOlderThan(new VersionNumber(d.version))) {
                     missingDependency = true;
                     LOGGER.log(Level.FINER, "{0} is missing a dependency on {1} version {2}",
-                            new Object[]{w.getShortName(), d.shortName, d.shortName});
+                            new Object[]{w.getShortName(), d.shortName, d.version});
                 }
             }
             for (PluginWrapper.Dependency d : w.getOptionalDependencies()) {
@@ -343,7 +343,7 @@ public class PluginHelper extends Descriptor<PluginHelper> implements Describabl
                 if (v != null && v.isOlderThan(new VersionNumber(d.version))) {
                     missingDependency = true;
                     LOGGER.log(Level.FINER, "{0} is missing a dependency on {1} version {2}",
-                            new Object[]{w.getShortName(), d.shortName, d.shortName});
+                            new Object[]{w.getShortName(), d.shortName, d.version});
                 }
             }
             if (missingDependency) {


### PR DESCRIPTION
optional-plugin-helper-module does not correctly exposing the version of a missed dependency

The bus is in this line of code:
https://github.com/jenkinsci/optional-plugin-helper-module/blob/2994c72c377d05eab48793e94dbbdcdf238ae79f/src/main/java/org/jenkinsci/modules/optpluginhelper/PluginHelper.java#L346

https://issues.jenkins-ci.org/browse/JENKINS-36820

@reviewbybees CC @varmenise @amuniz
